### PR TITLE
Added ReplayFlowableList to avoid issues with FlowableList being shar…

### DIFF
--- a/src/main/java/com/github/mproberts/rxtools/list/FlowableList.java
+++ b/src/main/java/com/github/mproberts/rxtools/list/FlowableList.java
@@ -330,9 +330,20 @@ public abstract class FlowableList<T>
      * to the underlying Flowable.
      * This is useful if you need to subscribe to the list's updates in several places and subscribing
      * is a costly operation.
+     * Consider using this operator with replayAndAutoConnect in case updates may be emitted before
+     * all subscribers are watching the updates.
      * @return A flowable list whose updates share a single subscription.
      */
     public FlowableList<T> share() {
         return new SharedFlowableList<>(updates());
+    }
+
+    /**
+     * Wraps the supplied list's update with the replay() and autoConnect() operators, allowing updates to be replayed.
+     * This can be useful when sharing a subscription, so that a later subscriber can still get the emissions.
+     * @return A flowable list whose updates will be wrapped with replay()
+     */
+    public FlowableList<T> replayAndAutoConnect(int bufferSize) {
+        return new ReplayFlowableList<>(updates(), bufferSize);
     }
 }

--- a/src/main/java/com/github/mproberts/rxtools/list/ReplayFlowableList.java
+++ b/src/main/java/com/github/mproberts/rxtools/list/ReplayFlowableList.java
@@ -1,0 +1,17 @@
+package com.github.mproberts.rxtools.list;
+
+import io.reactivex.Flowable;
+
+public class ReplayFlowableList<T> extends FlowableList<T> {
+
+    private Flowable<Update<T>> _updates;
+
+    ReplayFlowableList(Flowable<Update<T>> updates, int bufferSize) {
+        _updates = updates.replay(bufferSize).autoConnect();
+    }
+
+    @Override
+    public Flowable<Update<T>> updates() {
+        return _updates;
+    }
+}

--- a/src/test/java/com/github/mproberts/rxtools/list/ReplayFlowableListTest.java
+++ b/src/test/java/com/github/mproberts/rxtools/list/ReplayFlowableListTest.java
@@ -1,0 +1,58 @@
+package com.github.mproberts.rxtools.list;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableEmitter;
+import io.reactivex.FlowableOnSubscribe;
+import io.reactivex.subscribers.TestSubscriber;
+
+public class ReplayFlowableListTest {
+
+    @Test
+    public void testShareAndReplayForSecondSubscriber() {
+        final List<String> testList = new ArrayList<String>() {{
+            add("A");
+            add("B");
+            add("C");
+        }};
+
+        final AtomicInteger subCount = new AtomicInteger(0);
+
+        final Flowable<Update<String>> source = Flowable.create(new FlowableOnSubscribe<Update<String>>() {
+            @Override
+            public void subscribe(FlowableEmitter<Update<String>> flowableEmitter) throws Exception {
+                subCount.incrementAndGet();
+                flowableEmitter.onNext(new Update<String>(
+                    testList,
+                    Change.reloaded()
+                ));
+            }
+        }, BackpressureStrategy.BUFFER);
+
+        FlowableList<String> list = new FlowableList<String>() {
+            @Override
+            public Flowable<Update<String>> updates() {
+                return source;
+            }
+        }.share().replayAndAutoConnect(1);
+
+        // Subscribe to the values once
+        TestSubscriber sub1 = list.updates().test();
+        Assert.assertEquals(1, sub1.values().size());
+        Assert.assertEquals(testList, ((Update<String>) sub1.values().get(0)).list);
+        Assert.assertEquals(1, subCount.get());
+
+        // Subscribe to the values a second time
+        TestSubscriber sub2 = list.updates().test();
+        Assert.assertEquals(1, sub2.values().size());
+        Assert.assertEquals(testList, ((Update<String>) sub2.values().get(0)).list);
+        Assert.assertEquals(1, subCount.get());
+    }
+}


### PR DESCRIPTION
…ed and not emitting values again

Javadoc should explain why I need that. I figured it wasn't worth introducing two operators since you probably never need to replay without autoConnect.